### PR TITLE
Обработчик пакета

### DIFF
--- a/src/main/java/ru/mcmodding/tutorial/McModding.java
+++ b/src/main/java/ru/mcmodding/tutorial/McModding.java
@@ -23,7 +23,7 @@ public class McModding {
     )
     public static CommonProxy proxy;
 
-    public static final SimpleNetworkWrapper NETWORK = new SimpleNetworkWrapper(McModding.MOD_ID + ":channel");
+    public static final SimpleNetworkWrapper NETWORK = new SimpleNetworkWrapper(McModding.MOD_ID);
 
     public static final EventBus MODDING_BUS = new EventBus();
 

--- a/src/main/java/ru/mcmodding/tutorial/common/CommonProxy.java
+++ b/src/main/java/ru/mcmodding/tutorial/common/CommonProxy.java
@@ -14,7 +14,7 @@ import ru.mcmodding.tutorial.common.handler.packet.ServerMessagePacket;
 public class CommonProxy {
 
     public void preInit(FMLPreInitializationEvent event) {
-        McModding.NETWORK.registerMessage(new ServerMessagePacket(), ServerMessagePacket.class, 0, Side.SERVER);
+        McModding.NETWORK.registerMessage(new ServerMessagePacket.Handler(), ServerMessagePacket.class, 0, Side.SERVER);
 
         FMLCommonHandler.instance().bus().register(new FMLEventListener());
         MinecraftForge.EVENT_BUS.register(new ForgeEventListener());

--- a/src/main/java/ru/mcmodding/tutorial/common/handler/packet/ServerMessagePacket.java
+++ b/src/main/java/ru/mcmodding/tutorial/common/handler/packet/ServerMessagePacket.java
@@ -5,20 +5,25 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ChatComponentText;
 
-public class ServerMessagePacket implements IMessage, IMessageHandler<ServerMessagePacket, IMessage> {
+public class ServerMessagePacket implements IMessage {
+
+    // Набор полей данных пакета
     private String message;
     private int number;
 
     /**
-     * Должен быть пустым, чтобы во время регистрации пакета не приходилось указывать параметры.
+     * Наличие конструктора по-умолчанию (без параметров) обязательно, через него Forge
+     * создаёт экземпляр пакера каждый раз при получении от другой стороны.
      */
     public ServerMessagePacket() {
     }
 
     /**
-     * Будет использоваться для формирования пакета по параметрам.
+     * Будет использоваться для формирования пакета по параметрам. Наличие этого конструктора не обязательно,
+     * можно напрямую записывать значения в поля.
      *
      * @param message Сообщения, которое будет выводиться на серверной стороне.
      * @param number Число, которое будет выводиться на серверной стороне.
@@ -29,7 +34,7 @@ public class ServerMessagePacket implements IMessage, IMessageHandler<ServerMess
     }
 
     /**
-     * Данный метод вызывается при чтении из байтового буфера.
+     * Читает данные пакета из {@link ByteBuf} при получении.
      *
      * @see <a href="https://netty.io/4.0/api/io/netty/buffer/ByteBuf.html">ByteBuf</a>
      * @param buf Байтовый буфер используемый для чтения данных из пакета.
@@ -41,7 +46,7 @@ public class ServerMessagePacket implements IMessage, IMessageHandler<ServerMess
     }
 
     /**
-     * Данный метод вызывается при записи в байтовый буфер.
+     * Записывает данные пакета в {@link ByteBuf} перед отправкой.
      *
      * @see <a href="https://netty.io/4.0/api/io/netty/buffer/ByteBuf.html">ByteBuf</a>
      * @param buf Байтовый буфер используемый для записи данных в пакет.
@@ -53,19 +58,28 @@ public class ServerMessagePacket implements IMessage, IMessageHandler<ServerMess
     }
 
     /**
-     * Данный метод вызывается для обработки входящих данных из {@code message} пакета.
-     *
-     * @param packet Пакет с информацией. Рекомендуется использовать его для получения данных!
-     * @param ctx Контекст обработки пакетов. Позволяющий получить текущую сторону на которой было получено сообщение,
-     *            а также обработчиков(клиент и сервер)
-     * @return Возвращает пакет для ответа клиенту(ответ с клиента на сервер в данном случае не будет работать!)
+     * Этот класс отвечает за обработку входящих пакетов
      */
-    @Override
-    public IMessage onMessage(ServerMessagePacket packet, MessageContext ctx) {
-        String message = packet.message;
-        int number = packet.number;
-        // Отправляем сообщение игроку, который отправил пакет с данными.
-        ctx.getServerHandler().playerEntity.addChatMessage(new ChatComponentText("Вывожу текст \"" + message + "\" с числом \"" + number + "\""));
-        return null;
+    public static class Handler implements IMessageHandler<ServerMessagePacket, IMessage> {
+
+        /**
+         * Данный метод вызывается для обработки входящих данных из {@code message} пакета.
+         *
+         * @param packet Полученный пакет
+         * @param ctx Контекст обработки пакетов. Позволяющий получить текущую сторону на которой было получено сообщение,
+         * а также обработчиков(клиент и сервер)
+         * @return Возвращает пакет для ответа клиенту(ответ с клиента на сервер в данном случае не будет работать!)
+         */
+        @Override
+        public IMessage onMessage(ServerMessagePacket packet, MessageContext ctx) {
+            String message = packet.message;
+            int number = packet.number;
+            // Получаем игрока, который прислал нам пакет. Это единственный параметр, которому мы можем полностью доверять.
+            EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+
+            // Отправляем сообщение игроку
+            player.addChatMessage(new ChatComponentText("Вывожу текст \"" + message + "\" с числом \"" + number + "\""));
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Вынес обработчик пакета в подкласс, потому что совмещение `IMessage` и `IMessageHandler` на одном классе является плохой практикой из-за различного назначения этих интерфейсов и ни к чему хорошему кроме путаницы не приведёт. Планирую описать этот момент в учебнике.